### PR TITLE
Feature/fix midi message parsing

### DIFF
--- a/lib/midi.coffee
+++ b/lib/midi.coffee
@@ -9,6 +9,8 @@ L = utils = midi = midi_in = ___ = null
   ___ = utils.____ '[midi]'
 
 # Parse method copied from https://github.com/hhromic/midi-utils-js/blob/master/midiparser.js#L418
+# TODO Remove this parser in favor of midiHelp or if we continue to use this code, include the MIT
+# license as required by midiparser.js.
 parse = (port, msg) ->
   type = msg[0] & 0xF0
   channel = msg[0] & 0x0F

--- a/lib/osc.coffee
+++ b/lib/osc.coffee
@@ -20,6 +20,8 @@ utils = osc = ___ = null
   sender = new osc.UdpSender host, port, opts
   # can we store a shutdown function for this output and return the id in the closet and
   # return the function to send a message.
-  (path, val) ->  
-    #___ "out #{host}:#{port}", path, val
+  (path, val) ->
+    val.types ?= ''
+    val.values ?= []
+    ___ "out #{host}:#{port} #{path}?types=#{val.types}&values=#{val.values}"
     sender.send path, val.types, val.values

--- a/lib/router.coffee
+++ b/lib/router.coffee
@@ -27,7 +27,7 @@ class Router
   @dispatch = dispatch = (path, val) ->
     for id, [path_, cb] of routes
       if path.match path_
-        (utils.bind cb, path:path, val:val) val
+        (utils.bind cb, path:path, val:val) val, path
       else
         # I added this else branch to make sure that null entries are not added to the
         # results. I'm not sure if this is the desired behavior.

--- a/spec/midi_spec.coffee
+++ b/spec/midi_spec.coffee
@@ -97,11 +97,21 @@ describe 'legato.midi', ->
     expect(rtMidiMock.outputs[1].openVirtualPort).toHaveBeenCalled()
     expect(id1).not.toEqual id2, 'The two ouput ids should be unique.'
 
-#  it 'should close its output port when legato is closed.', ->
-#    legatoMidi.Out 'output1'
-#
-#    expect(rtMidiMock.outputs[0].closePort).not.toHaveBeenCalled()
+  it 'should correctly parse midi messages.', ->
+    mock = {
+      mockCallback: (path, value) -> console.log path, value
+    }
+    spyOn mock, 'mockCallback'
 
-#    legato.init()
+    midiRegister = midi.In('port1')
+    midiRegister( mock.mockCallback )
 
-#    expect(rtMidiMock.outputs[0].closePort).toHaveBeenCalled()
+    rtMidiMock.inputs[0].messageCallbacks[0](0, [153, 44, 103])
+
+    expect(mock.mockCallback).toHaveBeenCalledWith '/9/note/44', 103/127
+
+    rtMidiMock.inputs[0].messageCallbacks[0](0, [144, 62, 120])
+
+    expect(mock.mockCallback.calls.length).toBe 2
+    expect(mock.mockCallback.calls[1].args).toEqual ['/0/note/62', 120/127]
+


### PR DESCRIPTION
Midi message parsing was not working when legato received messages from actual hardware because legato.midi was acting as if the first value in midi messages was the message type. However, the first value is a binary number that includes the message type and channel so the parsing had to be updated to account for this. I'm not very good at binary operations so I stole the parsing routine in this file from another project.

I can now receive midi messages from hardware!!
